### PR TITLE
Fix attestation types to be usable in the SGX shim

### DIFF
--- a/src/attestation_types/mod.rs
+++ b/src/attestation_types/mod.rs
@@ -4,8 +4,8 @@
 //! Section references in further documentation refer to this document.
 //! https://www.intel.com/content/dam/www/public/emea/xe/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf
 
-#![cfg(feature = "std")]
-
+#[cfg(feature = "std")]
 pub mod quote;
+
 pub mod report;
 pub mod ti;

--- a/src/attestation_types/mod.rs
+++ b/src/attestation_types/mod.rs
@@ -6,6 +6,5 @@
 
 #[cfg(feature = "std")]
 pub mod quote;
-
 pub mod report;
 pub mod ti;

--- a/src/attestation_types/ti.rs
+++ b/src/attestation_types/ti.rs
@@ -7,7 +7,7 @@
 use crate::types::{attr::Attributes, misc::MiscSelect};
 
 /// Table 38-22
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(C, align(512))]
 pub struct TargetInfo {
     /// MRENCLAVE of the target enclave.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ macro_rules! testaso {
 #[cfg(feature = "crypto")]
 pub mod crypto;
 
-#[cfg(feature = "std")]
 pub mod attestation_types;
 
 #[cfg(feature = "std")]

--- a/src/types/secs.rs
+++ b/src/types/secs.rs
@@ -102,7 +102,7 @@ impl Secs {
 
         // Test for max enclave size
         let res = unsafe { __cpuid_count(LEAF_MAX_ENCL_SIZE, SUBLEAF_MAX_ENCL_SIZE) };
-        let max_size: u64 = 1 << (res.edx >> 8 as u8) as u64;
+        let max_size: u64 = 1 << (res.edx >> 8u8) as u64;
 
         NonZeroUsize::new(max_size as usize)
     }


### PR DESCRIPTION
This PR removes the `std` feature from `attestation_types` and attaches it only to the `Quote` type, such that we can use `TargetInfo` and `Report` inside the `no_std` shim. We should not need to read a `Quote` inside the shim, and the `Quote` relies on vectors that are only available in `std`.

Additionally, it adds `Copy` and `Clone` to `TargetInfo`.

Closes https://github.com/enarx/enarx/issues/755