### PR TITLE
Add conversions to CertDataType and AttestationKeyType

### DIFF
--- a/src/attestation_types/quote.rs
+++ b/src/attestation_types/quote.rs
@@ -125,6 +125,7 @@ pub struct SigData {
 }
 
 /// The type of Attestation Key used to sign the Report.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(u16)]
 pub enum AttestationKeyType {
     /// ECDSA-256-with-P-256 curve
@@ -137,6 +138,18 @@ pub enum AttestationKeyType {
 impl Default for AttestationKeyType {
     fn default() -> Self {
         AttestationKeyType::ECDSA256P256
+    }
+}
+
+impl TryFrom<u16> for AttestationKeyType {
+    type Error = QuoteError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            2 => Ok(AttestationKeyType::ECDSA256P256),
+            3 => Ok(AttestationKeyType::ECDSA384P384),
+            _ => Err(QuoteError(format!("Unknown value: {}", value))),
+        }
     }
 }
 

--- a/src/attestation_types/quote.rs
+++ b/src/attestation_types/quote.rs
@@ -6,7 +6,7 @@
 //! https://download.01.org/intel-sgx/dcap-1.0/docs/SGX_ECDSA_QuoteGenReference_DCAP_API_Linux_1.0.pdf
 
 use super::report::Body;
-use std::vec::Vec;
+use std::{fmt, vec::Vec};
 
 /// The Quote version for DCAP is 3. Must be 2 bytes.
 pub const VERSION: u16 = 3;
@@ -18,6 +18,18 @@ pub const ECDSASIGLEN: u32 = 64;
 pub const INTELVID: [u8; 16] = [
     0x93, 0x9A, 0x72, 0x33, 0xF7, 0x9C, 0x4C, 0xA9, 0x94, 0x0A, 0x0D, 0xB3, 0x95, 0x7F, 0x06, 0x07,
 ];
+
+#[derive(Clone, Debug)]
+/// Error type for Quote module
+pub struct QuoteError(String);
+
+impl fmt::Display for QuoteError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", &self.0)
+    }
+}
+
+impl std::error::Error for QuoteError {}
 
 /// Section A.4, Table 9
 #[repr(u16)]

--- a/src/attestation_types/quote.rs
+++ b/src/attestation_types/quote.rs
@@ -6,7 +6,7 @@
 //! https://download.01.org/intel-sgx/dcap-1.0/docs/SGX_ECDSA_QuoteGenReference_DCAP_API_Linux_1.0.pdf
 
 use super::report::Body;
-use std::{fmt, vec::Vec};
+use std::{convert::TryFrom, fmt, vec::Vec};
 
 /// The Quote version for DCAP is 3. Must be 2 bytes.
 pub const VERSION: u16 = 3;
@@ -32,6 +32,7 @@ impl fmt::Display for QuoteError {
 impl std::error::Error for QuoteError {}
 
 /// Section A.4, Table 9
+#[derive(Debug, Clone, Copy)]
 #[repr(u16)]
 pub enum CertDataType {
     /// Byte array that contains concatenation of PPID, CPUSVN,
@@ -63,6 +64,23 @@ pub enum CertDataType {
 impl Default for CertDataType {
     fn default() -> Self {
         Self::PCKCertChain
+    }
+}
+
+impl TryFrom<u16> for CertDataType {
+    type Error = QuoteError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(CertDataType::PpidPlaintext),
+            2 => Ok(CertDataType::PpidRSA2048OAEP),
+            3 => Ok(CertDataType::PpidRSA3072OAEP),
+            4 => Ok(CertDataType::PCKLeafCert),
+            5 => Ok(CertDataType::PCKCertChain),
+            6 => Ok(CertDataType::Quote),
+            7 => Ok(CertDataType::Manifest),
+            _ => Err(QuoteError(format!("Unknown Cert Data type: {}", value))),
+        }
     }
 }
 


### PR DESCRIPTION
A few more small additions to help create a `Quote` from bytes:

- Add a `QuoteError` type
- implement `From<u16>` for `CertDataType`
- implement `From<u16>` for `AttestationKeyType`
