### PR TITLE
Fix ReportData type and length

### DIFF
--- a/src/attestation_types/ti.rs
+++ b/src/attestation_types/ti.rs
@@ -23,7 +23,7 @@ pub struct TargetInfo {
 
 #[repr(C, align(128))]
 /// Pass information from the source enclave to the target enclave
-pub struct ReportData(pub [u8; 64]);
+pub struct ReportData(pub [u16; 32]);
 
 #[cfg(feature = "asm")]
 impl TargetInfo {


### PR DESCRIPTION
~~The Intel spec outlines this as [u16; 32]~~

Superseded by #23 