### PR TITLE
Standardize type of ReportData field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ crypto = ["std", "openssl" ]
 chain_get = [ "std", "percent-encoding", "reqwest"]
 std = ["iocuddle", "libc", "mmarinus", "vdso"]
 asm = ["xsave/asm"]
+serialize = [ "serde", "serde-big-array" ]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde-big-array = { version = "0.3.1", optional = true }
 xsave = { version = "0.1.1", default-features = false }
 iocuddle = { version = "0.1", optional = true }
 mmarinus = { version = "0.2", optional = true }

--- a/src/attestation_types/ti.rs
+++ b/src/attestation_types/ti.rs
@@ -5,6 +5,7 @@
 //! verify the REPORT structure returned by the EREPORT leaf. Must be 512-byte aligned.
 
 use crate::types::{attr::Attributes, misc::MiscSelect};
+use core::default::Default;
 
 /// Table 38-22
 #[derive(Default, Debug, Clone, Copy)]
@@ -21,9 +22,16 @@ pub struct TargetInfo {
     reserved2: [u64; 25],
 }
 
+#[derive(Clone, Copy)]
 #[repr(C, align(128))]
 /// Pass information from the source enclave to the target enclave
 pub struct ReportData(pub [u8; 64]);
+
+impl Default for ReportData {
+    fn default() -> Self {
+        ReportData([0u8; 64])
+    }
+}
 
 #[cfg(feature = "asm")]
 impl TargetInfo {

--- a/src/types/attr.rs
+++ b/src/types/attr.rs
@@ -3,12 +3,12 @@
 //! Attributes (Section 38.7.1)
 //! The attributes of an enclave are specified by the struct below as described.
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 bitflags::bitflags! {
     /// Section 38.7.1.
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct Flags: u64 {
         /// Enclave has been initialized by EINIT.
         const INIT = 1 << 0;
@@ -35,7 +35,7 @@ impl Default for Flags {
 
 bitflags::bitflags! {
     /// Section 42.7.2.1; more info can be found at https://en.wikipedia.org/wiki/Control_register.
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct Xfrm: u64 {
         /// x87 FPU/MMX State, note, must be '1'.
         const X87 = 1 << 0;
@@ -71,7 +71,7 @@ impl Default for Xfrm {
 /// Section 38.7.1.
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Attributes {
     flags: Flags,
     xfrm: Xfrm,

--- a/src/types/isv.rs
+++ b/src/types/isv.rs
@@ -3,19 +3,19 @@
 //! ISV_PRODID and ISVSVN in SIGSTRUCT (Table 38-19)
 //! Definitions for Independent Software Vendor Product ID and Security Version Number.
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 /// ISV assigned Product ID.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProdId(u16);
 
 /// ISV assigned SVN (security version number).
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Svn(u16);
 
 impl ProdId {

--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -4,13 +4,13 @@
 //! The bit vector of MISCSELECT selects which extended information is to be saved in the MISC
 //! region of the SSA frame when an AEX is generated.
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 bitflags::bitflags! {
     /// Section 38.7.2
     #[derive(Default)]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct MiscSelect: u32 {
         /// Report info about page faults and general protection exception that occurred inside an enclave.
         const EXINFO = 1 << 0;


### PR DESCRIPTION
Initially the `reportdata` field was a `[u16; 32]` instead of `[u8; 64]` so that we could `#[derive(Default)]` on the whole struct instead of implementing `Default` the long way. (Is there some shorter way to implement the `Default`? Suggestions welcome.)

This also requires serialization with `serde-big-array` on the `reportdata: [u8; 64]` field.