### PR TITLE
verify() to check measurement and return ReportData

### DIFF
--- a/src/attestation_types/verify/mod.rs
+++ b/src/attestation_types/verify/mod.rs
@@ -54,13 +54,14 @@ pub fn get_intel_cert_chain_pem() -> Result<String, Box<dyn Error>> {
     Ok(trusted_public_pck_chain.to_string())
 }
 
-/// Verify a quote against a trusted certificate chain
+/// Verify a quote against a trusted certificate chain and known good measurement. If successful,
+/// it will return the Report's ReportData field as bytes.
 #[allow(dead_code)]
 pub fn verify(
     quote_bytes: &[u8],
     trusted_public_pck_chain: &str,
     good_measurement: &[u8],
-) -> Result<(), Box<dyn Error>> {
+) -> Result<[u8; 64], Box<dyn Error>> {
     // The material (Quote Header || ISV Enclave Report) signed by Quoting Enclave's Attestation Key
     // is retrieved.
     let att_key_signed_material = Quote::raw_header_and_body(quote_bytes)?;
@@ -122,7 +123,10 @@ pub fn verify(
         ))));
     }
 
-    Ok(())
+    // Return ReportData as bytes
+    let mut reportdata = [0u8; 64];
+    reportdata.copy_from_slice(&report.reportdata[..]);
+    Ok(reportdata)
 }
 
 #[cfg(test)]

--- a/src/attestation_types/verify/samples.rs
+++ b/src/attestation_types/verify/samples.rs
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+/// A sample MRENCLAVE expected by testing
+#[allow(dead_code)]
+pub const SAMPLE_MRENCLAVE: [u8; 32] = [
+    180, 191, 170, 163, 153, 166, 115, 141, 209, 114, 31, 4, 206, 27, 234, 34, 70, 79, 197, 202,
+    28, 196, 124, 128, 26, 92, 175, 41, 184, 83, 61, 42,
+];
+
 /// A sample Quote to test verification
 #[allow(dead_code)]
 pub const SAMPLE_V3QUOTE: [u8; 4598] = [

--- a/src/attestation_types/verify/sig.rs
+++ b/src/attestation_types/verify/sig.rs
@@ -61,7 +61,7 @@ impl TryFrom<&Signature> for EcdsaSig {
     fn try_from(value: &Signature) -> Result<Self, Self::Error> {
         let r = BigNum::from_slice(&value.r)?;
         let s = BigNum::from_slice(&value.s)?;
-        Ok(EcdsaSig::from_private_components(r, s)?)
+        EcdsaSig::from_private_components(r, s)
     }
 }
 
@@ -69,7 +69,7 @@ impl TryFrom<&Signature> for EcdsaSig {
 impl TryFrom<&Signature> for Vec<u8> {
     type Error = ErrorStack;
     fn try_from(value: &Signature) -> Result<Self, Self::Error> {
-        Ok(EcdsaSig::try_from(value)?.to_der()?)
+        EcdsaSig::try_from(value)?.to_der()
     }
 }
 


### PR DESCRIPTION
Two commits to help the client code.

- Pass in a known-good measurement to `verify()` and check the measurement against this.
- `verify()` should return the `reportdata` value, as this will contain a hash of the pubkey for the certificate we're using.

Fixes #25 
Fixes #26 
