### PR TITLE
Add method to return Builder's hasher

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -19,6 +19,7 @@ use std::num::NonZeroU32;
 /// summarized at https://github.com/enarx/enarx/wiki/SGX-Measurement. The leaf
 /// functions are mimicked to obtain these values, but are not actually called here;
 /// to use them, refer to the [iocuddle-sgx](../../iocuddle-sgx) library.
+#[derive(Clone)]
 pub struct Hasher(sha::Sha256);
 
 impl Hasher {

--- a/src/enclave/builder.rs
+++ b/src/enclave/builder.rs
@@ -182,4 +182,10 @@ impl Builder {
 
         Ok(Arc::new(RwLock::new(Enclave::new(self.mmap, self.tcsp))))
     }
+
+    /// Return the Hasher struct. This can be used to get the enclave's
+    /// measurement without running the enclave.
+    pub fn hasher(&self) -> Hasher {
+        self.hash.clone()
+    }
 }


### PR DESCRIPTION
The Builder takes care of setting up the hasher correctly in `load`. After this point, returning the hasher allows us to use it directly to get a measurement.
