### PR TITLE
fix: do not use rbx register in asm!()

### DIFF
--- a/src/attestation_types/ti.rs
+++ b/src/attestation_types/ti.rs
@@ -50,10 +50,12 @@ impl TargetInfo {
         let mut report = core::mem::MaybeUninit::<report::Report>::uninit();
 
         asm!(
+            "xchg {RBX}, rbx",
             "enclu",
+            "mov rbx, {RBX}",
 
+            RBX = inout(reg) self => _,
             in("rax") EREPORT,
-            in("rbx") self,
             in("rcx") data.0.as_ptr(),
             in("rdx") report.as_mut_ptr(),
         );

--- a/src/enclave/enclave.rs
+++ b/src/enclave/enclave.rs
@@ -193,6 +193,7 @@ impl Thread {
         let rax: i32;
         unsafe {
             asm!(
+                "push rbx",       // save rbx
                 "push rbp",       // save rbp
                 "mov  rbp, rsp",  // save rsp
                 "and  rsp, ~0xf", // align to 16+0
@@ -203,6 +204,7 @@ impl Thread {
 
                 "mov  rsp, rbp",  // restore rsp
                 "pop  rbp",       // restore rbp
+                "pop  rbx",       // restore rbx
 
                 inout("rdi") usize::from(registers.rdi) => _,
                 inout("rsi") usize::from(registers.rsi) => _,
@@ -212,7 +214,6 @@ impl Thread {
                 inout("r9") usize::from(registers.r9) => _,
                 inout("r10") &mut run => _,
                 inout("r11") self.fnc => _,
-                lateout("rbx") _,
                 lateout("r12") _,
                 lateout("r13") _,
                 lateout("r14") _,


### PR DESCRIPTION
error: invalid register `rbx`: rbx is used internally by LLVM and
cannot be used as an operand for inline asm

See:
https://github.com/rust-lang/rust/pull/84658#issuecomment-831129762

and:
https://github.com/rust-lang/rust/pull/84658/files#diff-d7283132d97a993fad4e2d491ac883dbce4e17fe248cdf37fa3f9334e2a5a115
