### PR TITLE
Bump minimum Rust for const_if_match

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.45.0
+          - 1.46.0
           - stable
           - beta
           - nightly


### PR DESCRIPTION
It appears that the bitflags dependency now requires it.

Signed-off-by: Nathaniel McCallum <nathaniel@congru.us>
