### PR TITLE
Update x86_64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ asm = []
 std = []
 
 [dependencies]
-x86_64 = { git = "https://github.com/npmccallum/x86_64", branch = "errors", default-features = false }
+x86_64 = { version="0.14.5", default-features = false }
 openssl = { version = "0.10", optional = true }
 bitflags = "1.2"
 


### PR DESCRIPTION
Switch to using upstream, since the PR implementation depended on is now merged (https://github.com/rust-osdev/x86_64/pull/303)