### PR TITLE
feat(ioctls)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ x86_64 = { version = "^0.14.6", default-features = false }
 xsave = { version = "^2.0.0", default-features = false }
 openssl = { version = "^0.10.36", optional = true }
 bitflags = "^1.3.2"
+iocuddle = "0.1.1"
 
 # Used by the rcrypto feature (see above).
 num-integer = { version = "^0.1.44", optional = true }

--- a/src/ioctls.rs
+++ b/src/ioctls.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements Intel SGX-related IOCTLs using the iocuddle crate.
+//! All references to Section or Tables are from
+//! [Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 3D: System Programming Guide, Part 4](https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf)
+
+#![allow(dead_code)]
+
+use crate::page::{SecInfo, Secs};
+use crate::signature::Signature;
+
+use core::marker::PhantomData;
+
+use iocuddle::*;
+
+const SGX: Group = Group::new(0xA4);
+
+/// IOCTL identifier for ECREATE (see Section 41-21)
+pub const ENCLAVE_CREATE: Ioctl<Write, &Create<'_>> = unsafe { SGX.write(0x00) };
+
+/// IOCTL identifier for EADD (see Section 41-11)
+pub const ENCLAVE_ADD_PAGES: Ioctl<WriteRead, &AddPages<'_>> = unsafe { SGX.write_read(0x01) };
+
+/// IOCTL identifier for EINIT (see Section 41-35)
+pub const ENCLAVE_INIT: Ioctl<Write, &Init<'_>> = unsafe { SGX.write(0x02) };
+
+/// SGX_ENCLAVE_SET_ATTRIBUTE (0x03) is not used by Enarx.
+
+/// SGX_IOC_VEPC_REMOVE_ALL (0x04) is not used by Enarx.
+
+/// SGX_IOC_ENCLAVE_RELAX_PERMISSIONS (0x05) is not used by Enarx.
+
+/// SGX_IOC_ENCLAVE_RESTRICT_PERMISSIONS
+pub const ENCLAVE_RESTRICT_PERMISSIONS: Ioctl<WriteRead, &RestrictPermissions<'_>> =
+    unsafe { SGX.write_read(0x06) };
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for creating a new enclave from SECS
+pub struct Create<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> Create<'a> {
+    /// A new Create struct wraps an SECS struct from the sgx-types crate.
+    pub fn new(secs: &'a Secs) -> Self {
+        Create(secs as *const _ as _, PhantomData)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for adding pages to an enclave
+pub struct AddPages<'a> {
+    src: u64,
+    offset: u64,
+    length: u64,
+    secinfo: u64,
+    flags: u64,
+    count: u64,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> AddPages<'a> {
+    /// Creates a new AddPages struct for a page at a certain offset
+    pub fn new(bytes: &'a [u8], offset: usize, secinfo: &'a SecInfo, measure: bool) -> Self {
+        const MEASURE: u64 = 1 << 0;
+
+        let flags = match measure {
+            true => MEASURE,
+            false => 0,
+        };
+
+        Self {
+            src: bytes.as_ptr() as _,
+            offset: offset as _,
+            length: bytes.len() as _,
+            secinfo: secinfo as *const _ as _,
+            flags,
+            count: 0,
+            phantom: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    /// WIP
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for initializing an enclave
+pub struct Init<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> Init<'a> {
+    /// A new Init struct must wrap a Signature from the sgx-types crate.
+    pub fn new(sig: &'a Signature) -> Self {
+        Init(sig as *const _ as _, PhantomData)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+/// SGX_IOC_ENCLAVE_RELAX_PERMISSIONS parameter structure
+pub struct RestrictPermissions<'a> {
+    /// In: starting page offset
+    offset: u64,
+    /// In: length of the address range (multiple of the page size)
+    length: u64,
+    /// In: SECINFO containing the relaxed permissions
+    secinfo: u64,
+    /// Out: ENCLU[EMODPR] return value
+    result: u64,
+    /// Out: length of the address range successfully changed
+    count: u64,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> RestrictPermissions<'a> {
+    /// Create a new RestrictPermissions instance.
+    pub fn new(offset: usize, length: usize, secinfo: &'a SecInfo) -> Self {
+        Self {
+            offset: offset as _,
+            length: length as _,
+            secinfo: secinfo as *const _ as _,
+            result: 0,
+            count: 0,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Read result attribute.
+    pub fn result(&self) -> u64 {
+        self.count
+    }
+
+    /// Read count attribute.
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}
+
+#[cfg(all(test, host_can_test_sgx))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restrict_permissions() {
+        use sgx::page::{Flags, SecInfo};
+        use std::fs::OpenOptions;
+
+        let mut device_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/sgx_enclave")
+            .unwrap();
+
+        let secinfo = SecInfo::reg(Flags::empty());
+        let mut parameters = RestrictPermissions::new(0, 0, &secinfo);
+
+        let ret = match ENCLAVE_RESTRICT_PERMISSIONS.ioctl(&mut device_file, &mut parameters) {
+            Ok(_) => 0,
+            Err(err) => err.raw_os_error().unwrap(),
+        };
+
+        assert_eq!(ret, libc::EINVAL);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ macro_rules! testaso {
 //pub mod attestation_types;
 
 pub mod crypto;
+pub mod ioctls;
 pub mod page;
 pub mod parameters;
 pub mod signature;


### PR DESCRIPTION
Move ioctl shenanigans from enarx/enarx to enarx/sgx crate. Take away
ioctls that will be never used.

Closes: #66
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
