### PR TITLE
chore: handle no_std in a more elegant way

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!      `parameters` and `page` modules. However, you may also want the
 //!      `signature` module to load a signature.
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 #![deny(clippy::exhaustive_enums)]
 #![deny(clippy::all)]
 
@@ -81,6 +81,10 @@ macro_rules! testaso {
         }
     };
 }
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 
 //pub mod attestation_types;
 


### PR DESCRIPTION
I no longer need `std` for what I was working on. This may be useful however if we want to easily add `std`-exclusive features in the future.

Signed-off-by: Nicholas Farshidmehr <nicholas@profian.com>
