### PR TITLE
fix: don't panic on smaller-than-expected quotients

### DIFF
--- a/src/crypto/rcrypto.rs
+++ b/src/crypto/rcrypto.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 fn arr_from_big(value: &BigUint) -> [u8; 384] {
     let mut arr = [0u8; 384];
     let buf = value.to_bytes_le();
-    arr.copy_from_slice(&buf);
+    arr[..buf.len()].copy_from_slice(&buf);
     arr
 }
 


### PR DESCRIPTION
The behavior now appears to be equivalent to that of the analogous code on the OpenSSL side of things (see arr_from_bn in src/crypto/openssl.rs), but I'd appreciate someone with knowledge of the cryptography to sign off on this to make sure that there's not some subtle problem with this. A healthy dash of paranoia when it comes to all things cryptography. :P

Necessary for https://github.com/enarx/enarx/pull/1752 .
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
