### PR TITLE
refactor(sgx): rename `SecInfo::extend_permissions()` to `SecInfo::extend()`

### DIFF
--- a/src/page/sinfo.rs
+++ b/src/page/sinfo.rs
@@ -144,7 +144,7 @@ impl SecInfo {
     /// Extend page permissions.
     #[inline]
     #[cfg(target_arch = "x86_64")]
-    pub fn extend_permissions(&self, dest: Page) {
+    pub fn extend(&self, dest: Page) {
         unsafe {
             core::arch::asm!(
                 "xchg       {RBX}, rbx",


### PR DESCRIPTION
Link: https://github.com/enarx/enarx/pull/1776
Suggested-by: Nathaniel McCallum <nathaniel@profian.com>
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>
