### PR TITLE
feat: Intel assembly behind `x86_64` arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ rcrypto = ["rand", "rsa", "sha2", "num-integer", "num-traits"]
 
 [dependencies]
 x86_64 = { version = "^0.14.6", default-features = false }
-xsave = { version = "^2.0.0", default-features = false }
 openssl = { version = "^0.10.36", optional = true }
 bitflags = "^1.3.2"
 
@@ -35,6 +34,9 @@ num-traits = { version = "^0.2.14", optional = true }
 rand = { version = "^0.8.4", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 rsa = { version = "^0.6.0", optional = true }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+xsave = { version = "^2.0.0", default-features = false }
 
 [dev-dependencies]
 testaso = "0.1"

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -93,7 +93,7 @@ impl super::PrivateKey for RS256PrivateKey {
 
         Ok(super::SigData {
             signature: arr_from_bn(&s),
-            modulus: arr_from_bn(&*m),
+            modulus: arr_from_bn(m),
             exponent,
             q1: arr_from_bn(&*q1),
             q2: arr_from_bn(&*q2),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub mod crypto;
 pub mod page;
 pub mod parameters;
 pub mod signature;
+
+#[cfg(target_arch = "x86_64")]
 pub mod ssa;
 
 /// SGX ENCLU Leaf Instructions

--- a/src/page/class.rs
+++ b/src/page/class.rs
@@ -7,7 +7,7 @@ use crate::page::{Flags, SecInfo};
 /// page.
 #[repr(u8)]
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Class {
     /// SGX Enclave Control Structure (SECS)
     Secs = 0,

--- a/src/signature/hasher.rs
+++ b/src/signature/hasher.rs
@@ -6,7 +6,7 @@ use core::num::NonZeroU32;
 use core::slice::from_raw_parts;
 
 /// Input length is not a multiple of the page size
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct InvalidSize(());
 
 /// Hashes an enclave producing a measurement

--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -18,7 +18,7 @@ pub use xsave::XSave;
 
 /// Section 38.9.1.1, Table 38-9
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ExitType {
     Hardware,
     Software,


### PR DESCRIPTION
Reducing the dependencies needed for compiling for target `wasm32-wasi`. Needed for https://github.com/profianinc/steward/issues/26.

Tests pass for newly usable targets: `wasm32-wasi` with Enarx and `aarch64-unknown-linux-gnu` on Raspberry Pi.