### PR TITLE
docs: correct workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Workflow Status](https://github.com/enarx/sgx/workflows/test/badge.svg)](https://github.com/enarx/sgx/actions?query=workflow%3A%22test%22)
+[![Workflow Status](https://github.com/enarx/sgx/workflows/test/badge.svg)](https://github.com/enarx/sgx/actions?query=workflow%3A%22test%22+branch%3Amain)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/sgx.svg)](https://isitmaintained.com/project/enarx/sgx "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/sgx.svg)](https://isitmaintained.com/project/enarx/sgx "Percentage of issues still open")
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)


### PR DESCRIPTION
Fixed `Workflow Status` badge to only point to `main` branch.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
