### PR TITLE
feat: add missing fields of SIGSTRUCT

### DIFF
--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -51,7 +51,7 @@ impl super::PrivateKey for RS256PrivateKey {
 
     fn generate(exponent: u8) -> Result<Self, Self::Error> {
         let exponent = bn::BigNum::from_u32(exponent.into()).unwrap();
-        let key = rsa::Rsa::generate_with_e(384 * 8, &*exponent)?;
+        let key = rsa::Rsa::generate_with_e(384 * 8, &exponent)?;
         Ok(Self::new(key))
     }
 
@@ -95,8 +95,8 @@ impl super::PrivateKey for RS256PrivateKey {
             signature: arr_from_bn(&s),
             modulus: arr_from_bn(m),
             exponent,
-            q1: arr_from_bn(&*q1),
-            q2: arr_from_bn(&*q2),
+            q1: arr_from_bn(&q1),
+            q2: arr_from_bn(&q2),
         })
     }
 }

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -48,6 +48,12 @@ pub struct Parameters {
     /// CPU features for the enclave
     pub attr: Masked<Attributes>,
 
+    /// Extended ISV-defined family identifier
+    pub ext_fid: [u8; 16],
+
+    /// Extended ISV-defined product identifier
+    pub ext_pid: [u8; 16],
+
     /// ISV-defined product identifier
     pub pid: u16,
 

--- a/src/signature/body.rs
+++ b/src/signature/body.rs
@@ -14,10 +14,13 @@ impl Parameters {
     pub fn body(&self, mrenclave: [u8; 32]) -> Body {
         Body {
             misc: self.misc,
-            reserved0: [0; 20],
+            cet_attr: Masked { data: 0, mask: 0 },
+            reserved0: [0; 2],
+            ext_fid: [0; 16],
             attr: self.attr,
             mrenclave,
-            reserved1: [0; 32],
+            reserved1: [0; 16],
+            ext_pid: self.ext_pid,
             pid: self.pid,
             svn: self.svn,
         }
@@ -33,10 +36,13 @@ impl Parameters {
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Body {
     misc: Masked<MiscSelect>,
-    reserved0: [u8; 20],
+    cet_attr: Masked<u8>,
+    reserved0: [u8; 2],
+    ext_fid: [u8; 16],
     attr: Masked<Attributes>,
     mrenclave: [u8; 32],
-    reserved1: [u8; 32],
+    reserved1: [u8; 16],
+    ext_pid: [u8; 16],
     pid: u16,
     svn: u16,
 }
@@ -68,6 +74,8 @@ impl Body {
             svn: self.svn,
             misc: self.misc,
             attr: self.attr,
+            ext_pid: self.ext_pid,
+            ext_fid: self.ext_fid,
         }
     }
 }
@@ -80,10 +88,13 @@ mod test {
     testaso! {
         struct Body: 4, 128 => {
             misc: 0,
-            reserved0: 8,
+            cet_attr: 8,
+            reserved0: 10,
+            ext_fid: 12,
             attr: 28,
             mrenclave: 60,
             reserved1: 92,
+            ext_pid: 108,
             pid: 124,
             svn: 126
         }


### PR DESCRIPTION
Newer Intel specifications specify the following fields in SIGSTRUCT:
* ISV-defined product family identifier
* Extended ISV-defined product identifier
* CET Attributes

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
