### PR TITLE
feat: add AEXNOTIFY to Attributes Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,3 @@ xsave = { version = "^2.0.0", default-features = false }
 
 [dev-dependencies]
 testaso = "0.1"
-rstest = "^0.15.0"

--- a/src/parameters/attributes/features.rs
+++ b/src/parameters/attributes/features.rs
@@ -31,5 +31,8 @@ bitflags::bitflags! {
 
         /// Enables key separation and sharing
         const KSS = 1 << 7;
+
+        /// Enables the use of AEXNOTIFY
+        const AEXNOTIFY = 1 << 10;
     }
 }


### PR DESCRIPTION
"Intel Architecture Instruction Set Extensions and Future Features - Version 45" is out [2].  There is a new chapter:

Asynchronous Enclave Exit Notify and the EDECCSSA User Leaf Function.

Enclaves exit can be either synchronous and consensual (EEXIT for instance) or asynchronous (on an interrupt or fault).  The asynchronous ones can evidently be exploited to single step enclaves[1], on top of which other naughty things can be built.

AEX Notify will be made available both on upcoming processors and on some older processors through microcode updates.

1. https://github.com/jovanbulck/sgx-step
2. https://cdrdv2.intel.com/v1/dl/getContent/671368?explicitVersion=true

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/enarx/issues/2158


Also remove the unused `rstest` dependency, which prevents nightly compilation to succeed.