### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/page/flags.rs
+++ b/src/page/flags.rs
@@ -30,7 +30,7 @@ impl core::fmt::Display for Flags {
 
         for (flag, val) in opts {
             if self.contains(flag) {
-                write!(f, "{}", val)?;
+                write!(f, "{val}")?;
             }
         }
 

--- a/src/page/sinfo.rs
+++ b/src/page/sinfo.rs
@@ -110,7 +110,7 @@ impl SecInfo {
             0 => Ok(()),
             11 => Err(AcceptError::PageNotTracked),
             19 => Err(AcceptError::PageAttributesMismatch),
-            ret => panic!("EACCEPT returned an unknown error code: {}", ret),
+            ret => panic!("EACCEPT returned an unknown error code: {ret}"),
         }
     }
 
@@ -137,7 +137,7 @@ impl SecInfo {
         match ret {
             0 => Ok(()),
             19 => Err(AcceptError::PageAttributesMismatch),
-            ret => panic!("EACCEPTCOPY returned an unknown error code: {}", ret),
+            ret => panic!("EACCEPTCOPY returned an unknown error code: {ret}"),
         }
     }
 


### PR DESCRIPTION
```
error: variables can be used directly in the `format!` string
  --> src/page/flags.rs:33:17
   |
33 |                 write!(f, "{}", val)?;
   |                 ^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
note: the lint level is defined here
  --> src/lib.rs:20:9
   |
20 | #![deny(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[deny(clippy::uninlined_format_args)]` implied by `#[deny(clippy::all)]`
help: change this to
   |
33 -                 write!(f, "{}", val)?;
33 +                 write!(f, "{val}")?;
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
