### PR TITLE
chore: bump `rsa` to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ num-integer = { version = "^0.1.44", optional = true }
 num-traits = { version = "^0.2.14", optional = true }
 rand = { version = "^0.8.4", optional = true }
 sha2 = { version = "0.10.2", features = ["oid"], optional = true }
-rsa = { version = "^0.7.1", optional = true }
+rsa = { version = "0.8.1", features = ["sha2"], optional = true }
 const-oid = { version = "0.9.1", default-features = false, optional = true }
 der = { version = "0.6.1", optional = true }
 x509 = { version = "0.1", package = "x509-cert", default-features = false, optional = true }

--- a/src/crypto/rcrypto.rs
+++ b/src/crypto/rcrypto.rs
@@ -3,7 +3,7 @@
 use num_integer::Integer;
 use num_traits::ToPrimitive;
 use rand::thread_rng;
-use rsa::{pkcs1::DecodeRsaPrivateKey, BigUint, PaddingScheme, PublicKeyParts, RsaPrivateKey};
+use rsa::{pkcs1::DecodeRsaPrivateKey, BigUint, Pkcs1v15Sign, PublicKeyParts, RsaPrivateKey};
 use sha2::{Digest, Sha256};
 
 fn arr_from_big(value: &BigUint) -> [u8; 384] {
@@ -70,7 +70,7 @@ impl super::PrivateKey for RS256PrivateKey {
 
         let hash = Sha256::new().chain(author).chain(body).finalize();
 
-        let padding = PaddingScheme::new_pkcs1v15_sign::<Sha256>();
+        let padding = Pkcs1v15Sign::new::<Sha256>();
         let sig = self.0.sign(padding, &hash)?;
 
         // Calculate q1 and q2.


### PR DESCRIPTION
Fixes https://github.com/enarx/sgx/pull/114